### PR TITLE
Add FE validation

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,6 +3,9 @@ import { Layout } from 'antd';
 import 'antd/dist/antd.css';
 
 import { default as PageHeader } from './components/Header';
+import Forum from './pages/Forum';
+import Profile from './pages/Profile';
+import Configure from './pages/Configure';
 import Login from './pages/Login';
 import Register from './pages/Register';
 
@@ -17,7 +20,9 @@ function App() {
         <Content style={{padding: '50px'}}>
           <div style={{background: '#fff', height: '100%', padding: '20px'}}>
             <Routes>
-              <Route exact path="/" element={<Login />} />
+              <Route exact path="/" element={<Forum />} />
+              <Route exact path="/profile" element={<Profile />} />
+              <Route exact path="/configure" element={<Configure />} />
               <Route exact path="/login" element={<Login />} />
               <Route exact path="/register" element={<Register />} />
             </Routes>

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -14,15 +14,25 @@ const Header = () => {
 
   return (
     <Menu theme="dark" mode="horizontal" selectedKeys={[current]}>
-      <Menu.Item key={'sitename'}>Yet Another Dead Forum</Menu.Item>
+      <Menu.Item key={'sitename'}>
+        <Link to="/">Yet Another Dead Forum</Link>
+      </Menu.Item>
       <Menu.Item key={''} onClick={e => setCurrent(e.key)}>
         <Link to="/">Forums</Link>
       </Menu.Item>
       {state.auth.token &&
         (
-          <Menu.Item key={'logout'} onClick={handleLogout}>
-            <Link to="#">Logout</Link>
-          </Menu.Item>
+          <>
+            <Menu.Item key={'profile'} onClick={e => setCurrent(e.key)}>
+              <Link to="/profile">Profile</Link>
+            </Menu.Item>
+            <Menu.Item key={'configure'} onClick={e => setCurrent(e.key)}>
+              <Link to="/configure">Configure</Link>
+            </Menu.Item>
+            <Menu.Item key={'logout'} onClick={handleLogout}>
+              <Link to="#">Logout</Link>
+            </Menu.Item>
+          </>
         )
       }
       {!state.auth.token &&

--- a/frontend/src/pages/Configure.js
+++ b/frontend/src/pages/Configure.js
@@ -1,0 +1,10 @@
+import { Typography } from 'antd';
+
+const Configure = () => {
+  const { Title } = Typography;
+  return(
+    <Title style={{textAlign: 'center'}}>Configure</Title>
+  )
+};
+
+export default Configure;

--- a/frontend/src/pages/Forum.js
+++ b/frontend/src/pages/Forum.js
@@ -1,0 +1,22 @@
+import { useContext, useState } from 'react';
+import { Context } from '../store';
+import { Typography } from 'antd';
+
+const Forum = () => {
+  const [state, dispatch] = useContext(Context);
+  const { Title, Text } = Typography;
+  return(
+    <>
+      <Title style={{textAlign: 'center'}}>Forum</Title>
+      {
+        state.auth.token
+          ?
+          <Text>Logged in</Text>
+          :
+          <Text>Logged out</Text>
+      }
+    </>
+  )
+};
+
+export default Forum;

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -1,13 +1,15 @@
 import { useContext, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Form, Input, Button, Typography } from 'antd';
 import { Context } from '../store';
 import { loginUser } from '../store/actions';
 
 const Login = () => {
-  const [userName, setUsername] = useState('')
-  const [password, setPassword] = useState('')
-  const [error, setError] = useState('')
-  const [state, dispatch] = useContext(Context)
+  const [userName, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [state, dispatch] = useContext(Context);
+  const navigate = useNavigate();
 
   const { Title, Text } = Typography;
 
@@ -25,10 +27,11 @@ const Login = () => {
       body: JSON.stringify(userData),
     })
     
-    const returnData = await res.json()
+    const returnData = await res.json();
 
-    if(returnData.access_token) {
-      dispatch(loginUser(returnData))
+    if(returnData.token) {
+      dispatch(loginUser(returnData));
+      navigate('/', { replace: true });
     } else {
       let errors = ''
         if (returnData.error) {
@@ -63,7 +66,12 @@ const Login = () => {
             <Form.Item 
               label="Username"
               name="userName"
-              required
+              rules={[
+                {
+                  required: true,
+                  message: 'Please input your username!',
+                },
+              ]}
             >
               <Input
                 onChange={e => setUsername(e.target.value)}
@@ -73,7 +81,12 @@ const Login = () => {
             <Form.Item 
               label="Password"
               name="password"
-              required
+              rules={[
+                {
+                  required: true,
+                  message: 'Please input your password!',
+                },
+              ]}
             >
               <Input.Password
                 onChange={e => setPassword(e.target.value)}

--- a/frontend/src/pages/Profile.js
+++ b/frontend/src/pages/Profile.js
@@ -1,0 +1,10 @@
+import { Typography } from 'antd';
+
+const Profile = () => {
+  const { Title } = Typography;
+  return(
+    <Title style={{textAlign: 'center'}}>Profile</Title>
+  )
+};
+
+export default Profile;

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -3,7 +3,7 @@ import combineReducers from 'react-combine-reducers';
 import { authReducer } from './reducer';
 
 const initialAuth = {
-  token: null,
+  token: localStorage.getItem('token'),
   user: null,
 };
 

--- a/frontend/src/store/reducer.js
+++ b/frontend/src/store/reducer.js
@@ -5,16 +5,18 @@ const authReducer = (state, action) => {
     case USER_CREATE:
       return {
         ...state,
-        token: action.payload.access_token,
+        token: action.payload.token,
         user: action.payload.user,
       }
     case USER_LOGIN:
+      localStorage.setItem('token', action.payload.token);
       return {
         ...state,
-        token: action.payload.access_token,
+        token: action.payload.token,
         user: action.payload.user
       }
     case USER_LOGOUT:
+      localStorage.removeItem('token');
       return {
         ...state,
         token: null,


### PR DESCRIPTION
Adds front-end validation to the Login and Register pages. Saves token to localStorage so that the user remains logged in even after refreshing the page. 
Other page templates created.

NB! antDesign uses libraries that use findDOMNode - this will throw deprecation warnings all over your console. Just ignore these for now. The functionality still works and 🤞 antDesign actually eventually fix the issue.
(If you're curious here's the github thread: [horror](https://github.com/ant-design/ant-design/issues/22493))