### PR TITLE
Add profile endpoint, thread, posts and visitor endpoint

### DIFF
--- a/backend/src/main/java/ee/tlu/forum/controller/UserController.java
+++ b/backend/src/main/java/ee/tlu/forum/controller/UserController.java
@@ -43,4 +43,17 @@ public class UserController {
     public ResponseEntity<User> getUserById(@PathVariable Long id) {
         return ResponseEntity.ok().body(userService.getUserById(id));
     }
+
+    @DeleteMapping("/user/delete/id/{id}")
+    public ResponseEntity<User> deleteUserById(@PathVariable Long id) {
+        userService.deleteUserById(id);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/user/delete/username/{username}")
+    public ResponseEntity<User> deleteUserByUsername(@PathVariable String username) {
+        userService.deleteUserByUsername(username);
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/backend/src/main/java/ee/tlu/forum/controller/UserController.java
+++ b/backend/src/main/java/ee/tlu/forum/controller/UserController.java
@@ -1,6 +1,5 @@
 package ee.tlu.forum.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import ee.tlu.forum.model.User;
 import ee.tlu.forum.service.UserService;
 import lombok.extern.slf4j.Slf4j;
@@ -70,6 +69,18 @@ public class UserController {
     public ResponseEntity<?> getThreadCountByUserUsername(@PathVariable String username) {
         Map<String, Long> response = new HashMap<>();
         response.put("threadCount", userService.getUserThreadCount(username));
+        return ResponseEntity.ok().body(response);
+    }
+
+    @GetMapping("/user/{username}/profile")
+    public ResponseEntity<User> getUserProfile(@PathVariable String username) {
+        return ResponseEntity.ok().body(userService.getUserProfileByUsername(username));
+    }
+
+    @GetMapping("/user/{username}/visits")
+    public ResponseEntity<?> getUserVisitsCount(@PathVariable String username) {
+        Map<String, Long> response = new HashMap<>();
+        response.put("visits", userService.getUserProfileVisitsCount(username));
         return ResponseEntity.ok().body(response);
     }
 

--- a/backend/src/main/java/ee/tlu/forum/controller/UserController.java
+++ b/backend/src/main/java/ee/tlu/forum/controller/UserController.java
@@ -1,5 +1,6 @@
 package ee.tlu.forum.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import ee.tlu.forum.model.User;
 import ee.tlu.forum.service.UserService;
 import lombok.extern.slf4j.Slf4j;
@@ -8,7 +9,9 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @Slf4j
@@ -54,6 +57,20 @@ public class UserController {
     public ResponseEntity<User> deleteUserByUsername(@PathVariable String username) {
         userService.deleteUserByUsername(username);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/user/{username}/postcount")
+    public ResponseEntity<?> getPostCountByUserUsername(@PathVariable String username) {
+        Map<String, Long> response = new HashMap<>();
+        response.put("postCount", userService.getUserPostCount(username));
+        return ResponseEntity.ok().body(response);
+    }
+
+    @GetMapping("/user/{username}/threadcount")
+    public ResponseEntity<?> getThreadCountByUserUsername(@PathVariable String username) {
+        Map<String, Long> response = new HashMap<>();
+        response.put("threadCount", userService.getUserThreadCount(username));
+        return ResponseEntity.ok().body(response);
     }
 
 }

--- a/backend/src/main/java/ee/tlu/forum/model/Thread.java
+++ b/backend/src/main/java/ee/tlu/forum/model/Thread.java
@@ -19,7 +19,7 @@ import java.util.Collection;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-//@JsonIgnoreProperties({"hibernateLazyInitializer", "handler", "post"})
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 public class Thread extends BaseEntity {
 
     @Id

--- a/backend/src/main/java/ee/tlu/forum/model/User.java
+++ b/backend/src/main/java/ee/tlu/forum/model/User.java
@@ -1,7 +1,5 @@
 package ee.tlu.forum.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.sun.istack.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -18,7 +16,6 @@ import java.util.Collection;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-//@JsonIgnoreProperties({"hibernateLazyInitializer", "handler", "threads", "posts"})
 @Table(name = "users") // 'user' is a reserved keyword and cannot be used
 public class User extends BaseEntity {
 
@@ -56,10 +53,10 @@ public class User extends BaseEntity {
     private String signature = "";
 
     @OneToMany(mappedBy = "author", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-//    @JsonManagedReference
+
     private Collection<Thread> threads = new ArrayList<>();
 
     @OneToMany(mappedBy = "author", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-//    @JsonManagedReference
+
     private Collection<Post> posts = new ArrayList<>();
 }

--- a/backend/src/main/java/ee/tlu/forum/model/User.java
+++ b/backend/src/main/java/ee/tlu/forum/model/User.java
@@ -46,9 +46,9 @@ public class User extends BaseEntity {
     @ManyToMany(fetch = FetchType.EAGER)
     private Collection<Role> roles = new ArrayList<>();
 
-    private String about;
+    private String about = "";
 
-    private String signature;
+    private String signature = "";
 
     @OneToMany(mappedBy = "author", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
 //    @JsonManagedReference

--- a/backend/src/main/java/ee/tlu/forum/model/User.java
+++ b/backend/src/main/java/ee/tlu/forum/model/User.java
@@ -46,8 +46,13 @@ public class User extends BaseEntity {
     @ManyToMany(fetch = FetchType.EAGER)
     private Collection<Role> roles = new ArrayList<>();
 
+    @NotNull
     private String about = "";
 
+    @NotNull
+    private Long visits = 0L;
+
+    @NotNull
     private String signature = "";
 
     @OneToMany(mappedBy = "author", fetch = FetchType.LAZY, cascade = CascadeType.ALL)

--- a/backend/src/main/java/ee/tlu/forum/security/SecurityConfig.java
+++ b/backend/src/main/java/ee/tlu/forum/security/SecurityConfig.java
@@ -48,12 +48,12 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
         // allow only certain roles access to these endpoints
         http.authorizeRequests().antMatchers(GET, "/api/users/**").hasAnyAuthority("ROLE_USER");
-        http.authorizeRequests().antMatchers(GET, "/api/user/**").hasAnyAuthority("ROLE_USER");
+        http.authorizeRequests().antMatchers(GET, "/api/user/*").hasAnyAuthority("ROLE_USER");
         http.authorizeRequests().antMatchers(POST, "/api/user/save/**").hasAnyAuthority("ROLE_ADMIN");
 
         // allow every URL to every non-logged in user
         http.authorizeRequests().antMatchers("/api/**").permitAll();
-//        http.authorizeRequests().antMatchers("/api/roles").permitAll();
+        http.authorizeRequests().antMatchers("/api/roles").permitAll();
 
         http.authorizeRequests().anyRequest().authenticated(); // need to be authenticated
 

--- a/backend/src/main/java/ee/tlu/forum/service/PaymentService.java
+++ b/backend/src/main/java/ee/tlu/forum/service/PaymentService.java
@@ -1,15 +1,10 @@
 package ee.tlu.forum.service;
 
-import ee.tlu.forum.exception.NotFoundException;
 import ee.tlu.forum.model.Donation;
-import ee.tlu.forum.model.User;
 import ee.tlu.forum.model.input.DonationInput;
 import ee.tlu.forum.model.input.EverypayResponse;
 import ee.tlu.forum.model.output.EverypayData;
 import ee.tlu.forum.model.output.EverypayLink;
-import ee.tlu.forum.repository.DonationRepository;
-import ee.tlu.forum.repository.UserRepository;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;

--- a/backend/src/main/java/ee/tlu/forum/service/UserService.java
+++ b/backend/src/main/java/ee/tlu/forum/service/UserService.java
@@ -158,7 +158,7 @@ public class UserService implements UserServiceInterface, UserDetailsService {
     }
 
     @Override
-    public Long getUserVisitsCount(String username) {
+    public Long getUserProfileVisitsCount(String username) {
         return null;
     }
 

--- a/backend/src/main/java/ee/tlu/forum/service/UserService.java
+++ b/backend/src/main/java/ee/tlu/forum/service/UserService.java
@@ -4,6 +4,7 @@ import ee.tlu.forum.exception.AlreadyExistsException;
 import ee.tlu.forum.exception.BadRequestException;
 import ee.tlu.forum.exception.NotFoundException;
 import ee.tlu.forum.model.Role;
+import ee.tlu.forum.model.Thread;
 import ee.tlu.forum.model.User;
 import ee.tlu.forum.repository.RoleRepository;
 import ee.tlu.forum.repository.UserRepository;
@@ -149,12 +150,26 @@ public class UserService implements UserServiceInterface, UserDetailsService {
 
     @Override
     public Long getUserPostCount(String username) {
-        return null;
+        if (username == null) {
+            throw new BadRequestException("Cannot get post count without username.");
+        }
+        Optional<User> user = userRepository.findByUsername(username);
+        if (user.isEmpty()) {
+            throw new NotFoundException("No user with username " + username + " exists.");
+        }
+        return (long) user.get().getPosts().size();
     }
 
     @Override
     public Long getUserThreadCount(String username) {
-        return null;
+        if (username == null) {
+            throw new BadRequestException("Cannot get thread count without username.");
+        }
+        Optional<User> user = userRepository.findByUsername(username);
+        if (user.isEmpty()) {
+            throw new NotFoundException("No user with username " + username + " exists.");
+        }
+        return (long) user.get().getThreads().size();
     }
 
     @Override

--- a/backend/src/main/java/ee/tlu/forum/service/UserService.java
+++ b/backend/src/main/java/ee/tlu/forum/service/UserService.java
@@ -173,8 +173,20 @@ public class UserService implements UserServiceInterface, UserDetailsService {
     }
 
     @Override
+    public User getUserProfileByUsername(String username) {
+        User user = getUserByUsername(username);
+        user.setVisits(user.getVisits() + 1);
+        return user;
+    }
+
+    @Override
     public Long getUserProfileVisitsCount(String username) {
-        return null;
+        Optional<User> user = userRepository.findByUsername(username);
+        if (user.isEmpty()) {
+            throw new NotFoundException("Username does not exist");
+        }
+        log.info("Fetching user profile visits for: {}", username);
+        return user.get().getVisits();
     }
 
     @Override

--- a/backend/src/main/java/ee/tlu/forum/service/UserService.java
+++ b/backend/src/main/java/ee/tlu/forum/service/UserService.java
@@ -46,9 +46,7 @@ public class UserService implements UserServiceInterface, UserDetailsService {
             log.info("User {} found in the database", username);
         }
         Collection<SimpleGrantedAuthority> authorities = new ArrayList<>();
-        user.get().getRoles().forEach(role -> {
-            authorities.add(new SimpleGrantedAuthority(role.getName()));
-        });
+        user.get().getRoles().forEach(role -> authorities.add(new SimpleGrantedAuthority(role.getName())));
         return new org.springframework.security.core.userdetails.User(user.get().getUsername(), user.get().getPassword(), authorities);
         // return spring security's User class location to not mix up with the forum's own User class.
     }
@@ -109,10 +107,10 @@ public class UserService implements UserServiceInterface, UserDetailsService {
 
     @Override
     public void addRoleToUser(String username, String roleName) {
-        if (!userRepository.findByUsername(username).isPresent()) {
+        if (userRepository.findByUsername(username).isEmpty()) {
             throw new NotFoundException("User does not exist.");
         }
-        if (!roleRepository.findByName(roleName).isPresent()) {
+        if (roleRepository.findByName(roleName).isEmpty()) {
             throw new NotFoundException("Role does not exist.");
         }
         User user = userRepository.findByUsername(username).get();
@@ -142,7 +140,7 @@ public class UserService implements UserServiceInterface, UserDetailsService {
 
     @Override
     public User getUserByUsername(String username) {
-        if (!userRepository.findByUsername(username).isPresent()) {
+        if (userRepository.findByUsername(username).isEmpty()) {
             throw new NotFoundException("Username does not exist");
         }
         log.info("Fetching user with username {}", username);
@@ -150,7 +148,7 @@ public class UserService implements UserServiceInterface, UserDetailsService {
     }
 
     public User getUserByEmail(String email) {
-        if (!userRepository.findByEmail(email).isPresent()) {
+        if (userRepository.findByEmail(email).isEmpty()) {
             throw new NotFoundException("E-mail does not exist");
         }
         log.info("Fetching user with email {}", email);
@@ -158,7 +156,7 @@ public class UserService implements UserServiceInterface, UserDetailsService {
     }
 
     public Role getRoleByName(String name) {
-        if (!roleRepository.findByName(name).isPresent()) {
+        if (roleRepository.findByName(name).isEmpty()) {
             throw new NotFoundException("Role does not exist");
         }
         return roleRepository.findByName(name).get();

--- a/backend/src/main/java/ee/tlu/forum/service/UserService.java
+++ b/backend/src/main/java/ee/tlu/forum/service/UserService.java
@@ -147,6 +147,41 @@ public class UserService implements UserServiceInterface, UserDetailsService {
         return userRepository.findByUsername(username).get();
     }
 
+    @Override
+    public Long getUserPostCount(String username) {
+        return null;
+    }
+
+    @Override
+    public Long getUserThreadCount(String username) {
+        return null;
+    }
+
+    @Override
+    public Long getUserVisitsCount(String username) {
+        return null;
+    }
+
+    @Override
+    public void deleteUserById(Long id) {
+        Optional<User> user = userRepository.findById(id);
+        if (user.isEmpty()) {
+            throw new NotFoundException("User with ID " + id + " does not exist");
+        }
+        log.info("Deleting user with ID: {}", id);
+        userRepository.delete(user.get());
+    }
+
+    @Override
+    public void deleteUserByUsername(String username) {
+        Optional<User> user = userRepository.findByUsername(username);
+        if (user.isEmpty()) {
+            throw new NotFoundException("Username does not exist");
+        }
+        log.info("Deleting user: {}", username);
+        userRepository.delete(user.get());
+    }
+
     public User getUserByEmail(String email) {
         if (userRepository.findByEmail(email).isEmpty()) {
             throw new NotFoundException("E-mail does not exist");

--- a/backend/src/main/java/ee/tlu/forum/service/UserServiceInterface.java
+++ b/backend/src/main/java/ee/tlu/forum/service/UserServiceInterface.java
@@ -18,4 +18,5 @@ public interface UserServiceInterface{
     Long getUserProfileVisitsCount(String username);
     void deleteUserById(Long id);
     void deleteUserByUsername(String username);
+    User getUserProfileByUsername(String username);
 }

--- a/backend/src/main/java/ee/tlu/forum/service/UserServiceInterface.java
+++ b/backend/src/main/java/ee/tlu/forum/service/UserServiceInterface.java
@@ -13,4 +13,9 @@ public interface UserServiceInterface{
     List<User> getUsers();
     User getUserById(Long id);
     User getUserByUsername(String username);
+    Long getUserPostCount(String username);
+    Long getUserThreadCount(String username);
+    Long getUserVisitsCount(String username);
+    void deleteUserById(Long id);
+    void deleteUserByUsername(String username);
 }

--- a/backend/src/main/java/ee/tlu/forum/service/UserServiceInterface.java
+++ b/backend/src/main/java/ee/tlu/forum/service/UserServiceInterface.java
@@ -15,7 +15,7 @@ public interface UserServiceInterface{
     User getUserByUsername(String username);
     Long getUserPostCount(String username);
     Long getUserThreadCount(String username);
-    Long getUserVisitsCount(String username);
+    Long getUserProfileVisitsCount(String username);
     void deleteUserById(Long id);
     void deleteUserByUsername(String username);
 }

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -8,7 +8,6 @@ INSERT INTO public.users (created_at, updated_at, about, email, password, signat
 INSERT INTO public.users (created_at, updated_at, about, email, password, signature, username, visits) VALUES ('2021-11-20 21:22:36.115454', '2021-11-20 21:22:36.116453', '', 'foo@test.com', '$2a$10$xnUvv01NPMsvYQEYINiACOZTADPCoD9N6jjd7LSS4tYoYPZNdmXEG', '', 'Foo', 0) ON CONFLICT DO NOTHING;
 INSERT INTO public.users (created_at, updated_at, about, email, password, signature, username, visits) VALUES ('2021-11-20 21:22:36.115454', '2021-11-20 21:22:36.116453', '', 'bar@test.com', '$2a$10$xnUvv01NPMsvYQEYINiACOZTADPCoD9N6jjd7LSS4tYoYPZNdmXEG', '', 'Bar', 0) ON CONFLICT DO NOTHING;
 
-INSERT INTO public.users_roles (user_id, roles_id)
 SELECT
     1, 1
 WHERE NOT EXISTS (
@@ -37,112 +36,172 @@ WHERE NOT EXISTS (
     );
 
 -- threads
-INSERT INTO public.thread(text, title, user_id) VALUES (
+INSERT INTO public.thread(text, title, user_id) SELECT
     'Somebody please elaborate, I''m tired of the double standards.',
     'Why do people say they “slept like a baby” when babies often wake up like every two hours?',
-    1) ON CONFLICT DO NOTHING;
+    1
+WHERE NOT EXISTS (
+        SELECT 1 FROM public.thread WHERE thread.id = 1
+    );
 
-INSERT INTO public.thread(text, title, user_id) VALUES (
+INSERT INTO public.thread(text, title, user_id) SELECT
    'I think it''s not really the sound, but the feeling of clicking a pen that is actually satisfying. It''s like working a fidget spinner; there''s something really soothing about it. When someone else is doing it, you hear the sound and expect the satisfying click-click feeling on your fingers but don''t, hence the annoyance.',
    'You only like the pen clicking noise when you are the one making it',
-   1) ON CONFLICT DO NOTHING;
+   1
+WHERE NOT EXISTS (
+        SELECT 1 FROM public.thread WHERE thread.id = 2
+    );
 
-INSERT INTO public.thread(text, title, user_id) VALUES (
+INSERT INTO public.thread(text, title, user_id) SELECT
    'It''s over there by the baby food',
    'If you don''t know what it is, toothpaste sounds pretty terrifying',
-   2) ON CONFLICT DO NOTHING;
+   2
+WHERE NOT EXISTS (
+        SELECT 1 FROM public.thread WHERE thread.id = 3
+    );
 
-INSERT INTO public.thread(text, title, user_id) VALUES (
+INSERT INTO public.thread(text, title, user_id) SELECT
    'Yup. Also, the long title is on purpose :). No posts here!',
    'As data showing the effects of sugar on the human body become more well known, future generations will look back with horror on our practice of sending children out to trick-or-treat.',
-   3) ON CONFLICT DO NOTHING;
+   3
+WHERE NOT EXISTS (
+        SELECT 1 FROM public.thread WHERE thread.id = 4
+    );
 
-INSERT INTO public.thread(text, title, user_id) VALUES (
+INSERT INTO public.thread(text, title, user_id) SELECT
    'A perpetual stew, also known as hunter''s pot or hunter''s stew, is a pot into which whatever one can find is placed and cooked. The pot is never or rarely emptied all the way, and ingredients and liquid are replenished as necessary. The concept is often a common element in descriptions of medieval inns. Foods prepared in a perpetual stew have been described as being flavorful due to the manner in which the ingredients blend together, in which the flavor may improve with age.',
    'A soup can''t go bad if you just never stop boiling it...',
-   2) ON CONFLICT DO NOTHING;
+   2
+WHERE NOT EXISTS (
+        SELECT 1 FROM public.thread WHERE thread.id = 5
+);
 
 
 
 -- posts
 
 -- posts for thread 1
-INSERT INTO public.post(text, user_id, thread_id) VALUES (
+INSERT INTO public.post(text, user_id, thread_id) SELECT
   'Basically my university sleep schedule lol',
   2,
-  1);
+  1
+WHERE NOT EXISTS (
+        SELECT 1 FROM public.post WHERE post.id = 1
+    );
 
-INSERT INTO public.post(text, user_id, thread_id) VALUES (
+INSERT INTO public.post(text, user_id, thread_id) SELECT
      'Eh.. I most likely get less sleep as a parent.',
      3,
-     1);
+     1
+WHERE NOT EXISTS (
+        SELECT 1 FROM public.post WHERE post.id = 2
+    );
 
-INSERT INTO public.post(text, user_id, thread_id) VALUES (
+INSERT INTO public.post(text, user_id, thread_id) SELECT
      'You guys get sleep???.',
      1,
-     1);
+     1
+WHERE NOT EXISTS (
+        SELECT 1 FROM public.post WHERE post.id = 3
+    );
 
 -- posts for thread 2
-INSERT INTO public.post(text, user_id, thread_id) VALUES (
+INSERT INTO public.post(text, user_id, thread_id) SELECT
      'Ticking of a clock is the same as clicking pens, they seem to get louder when you pay attention and then it is all you can hear.',
      2,
-     2);
+     2
+WHERE NOT EXISTS (
+        SELECT 1 FROM public.post WHERE post.id = 4
+    );
 
-INSERT INTO public.post(text, user_id, thread_id) VALUES (
+INSERT INTO public.post(text, user_id, thread_id) SELECT
      'There are tons of noises that are only okay if you’re the one making the noise',
      3,
-     2);
+     2
+WHERE NOT EXISTS (
+        SELECT 1 FROM public.post WHERE post.id = 5
+    );
 
-INSERT INTO public.post(text, user_id, thread_id) VALUES (
+INSERT INTO public.post(text, user_id, thread_id) SELECT
      'Humming. Whistling. Doopdeedoopin.',
      1,
-     2);
+     2
+WHERE NOT EXISTS (
+        SELECT 1 FROM public.post WHERE post.id = 6
+    );
 
-INSERT INTO public.post(text, user_id, thread_id) VALUES (
+INSERT INTO public.post(text, user_id, thread_id) SELECT
      'elaborate on "Doopdeedoopin"',
      3,
-     2);
+     2
+WHERE NOT EXISTS (
+        SELECT 1 FROM public.post WHERE post.id = 7
+    );
 
-INSERT INTO public.post(text, user_id, thread_id) VALUES (
+INSERT INTO public.post(text, user_id, thread_id) SELECT
      'doop dee doop de dadla do',
      1,
-     2);
+     2
+WHERE NOT EXISTS (
+        SELECT 1 FROM public.post WHERE post.id = 8
+    );
 
-INSERT INTO public.post(text, user_id, thread_id) VALUES (
+INSERT INTO public.post(text, user_id, thread_id) SELECT
      '@Testing gets it.',
      2,
-     2);
+     2
+WHERE NOT EXISTS (
+        SELECT 1 FROM public.post WHERE post.id = 9
+    );
 
 -- posts for thread 3
-INSERT INTO public.post(text, user_id, thread_id) VALUES (
+INSERT INTO public.post(text, user_id, thread_id) SELECT
      'Not at all.. it sounds like something you could buy at a hardware store to repair your teeth with.. Broke a tooth? Get some toothpaste and patch it up.',
      1,
-     3);
+     3
+WHERE NOT EXISTS (
+        SELECT 1 FROM public.post WHERE post.id = 10
+    );
 
-INSERT INTO public.post(text, user_id, thread_id) VALUES (
+INSERT INTO public.post(text, user_id, thread_id) SELECT
      '@Testing Maybe it''s a paste made out of tooth',
      2,
-     3);
+     3
+WHERE NOT EXISTS (
+        SELECT 1 FROM public.post WHERE post.id = 11
+    );
 
-INSERT INTO public.post(text, user_id, thread_id) VALUES (
+INSERT INTO public.post(text, user_id, thread_id) SELECT
      'Not as bad as baby oil...',
      3,
-     3);
+     3
+WHERE NOT EXISTS (
+        SELECT 1 FROM public.post WHERE post.id = 12
+    );
 
-INSERT INTO public.post(text, user_id, thread_id) VALUES (
+INSERT INTO public.post(text, user_id, thread_id) SELECT
      '@Bar That''s just crude',
      2,
-     3);
+     3
+WHERE NOT EXISTS (
+        SELECT 1 FROM public.post WHERE post.id = 13
+    );
 
-INSERT INTO public.post(text, user_id, thread_id) VALUES (
+INSERT INTO public.post(text, user_id, thread_id) SELECT
      'Now I hate baby oil.',
      1,
-     3);
+     3
+WHERE NOT EXISTS (
+        SELECT 1 FROM public.post WHERE post.id = 14
+    );
 
 -- thread 4 is empty
 
 -- posts for thread 5
-INSERT INTO public.post(text, user_id, thread_id) VALUES (
+INSERT INTO public.post(text, user_id, thread_id) SELECT
      'Reserved.',
      2,
-     5);
+     5
+WHERE NOT EXISTS (
+        SELECT 1 FROM public.post WHERE post.id = 15
+    );

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -4,9 +4,9 @@ INSERT INTO public.role(name) VALUES ('ROLE_MODERATOR') ON CONFLICT DO NOTHING;
 INSERT INTO public.role(name) VALUES ('ROLE_PREMIUM') ON CONFLICT DO NOTHING;
 
 -- username 'Testing', password is 'test'
-INSERT INTO public.users (created_at, updated_at, about, email, password, signature, username) VALUES ('2021-11-20 21:22:36.115454', '2021-11-20 21:22:36.116453', '', 'test@test.com', '$2a$10$xnUvv01NPMsvYQEYINiACOZTADPCoD9N6jjd7LSS4tYoYPZNdmXEG', '', 'Testing') ON CONFLICT DO NOTHING;
-INSERT INTO public.users (created_at, updated_at, about, email, password, signature, username) VALUES ('2021-11-20 21:22:36.115454', '2021-11-20 21:22:36.116453', '', 'foo@test.com', '$2a$10$xnUvv01NPMsvYQEYINiACOZTADPCoD9N6jjd7LSS4tYoYPZNdmXEG', '', 'Foo') ON CONFLICT DO NOTHING;
-INSERT INTO public.users (created_at, updated_at, about, email, password, signature, username) VALUES ('2021-11-20 21:22:36.115454', '2021-11-20 21:22:36.116453', '', 'bar@test.com', '$2a$10$xnUvv01NPMsvYQEYINiACOZTADPCoD9N6jjd7LSS4tYoYPZNdmXEG', '', 'Bar') ON CONFLICT DO NOTHING;
+INSERT INTO public.users (created_at, updated_at, about, email, password, signature, username, visits) VALUES ('2021-11-20 21:22:36.115454', '2021-11-20 21:22:36.116453', '', 'test@test.com', '$2a$10$xnUvv01NPMsvYQEYINiACOZTADPCoD9N6jjd7LSS4tYoYPZNdmXEG', '', 'Testing', 0) ON CONFLICT DO NOTHING;
+INSERT INTO public.users (created_at, updated_at, about, email, password, signature, username, visits) VALUES ('2021-11-20 21:22:36.115454', '2021-11-20 21:22:36.116453', '', 'foo@test.com', '$2a$10$xnUvv01NPMsvYQEYINiACOZTADPCoD9N6jjd7LSS4tYoYPZNdmXEG', '', 'Foo', 0) ON CONFLICT DO NOTHING;
+INSERT INTO public.users (created_at, updated_at, about, email, password, signature, username, visits) VALUES ('2021-11-20 21:22:36.115454', '2021-11-20 21:22:36.116453', '', 'bar@test.com', '$2a$10$xnUvv01NPMsvYQEYINiACOZTADPCoD9N6jjd7LSS4tYoYPZNdmXEG', '', 'Bar', 0) ON CONFLICT DO NOTHING;
 
 INSERT INTO public.users_roles (user_id, roles_id)
 SELECT

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -4,9 +4,9 @@ INSERT INTO public.role(name) VALUES ('ROLE_MODERATOR') ON CONFLICT DO NOTHING;
 INSERT INTO public.role(name) VALUES ('ROLE_PREMIUM') ON CONFLICT DO NOTHING;
 
 -- username 'Testing', password is 'test'
-INSERT INTO public.users (created_at, updated_at, about, email, password, signature, username) VALUES ('2021-11-20 21:22:36.115454', '2021-11-20 21:22:36.116453', null, 'test@test.com', '$2a$10$xnUvv01NPMsvYQEYINiACOZTADPCoD9N6jjd7LSS4tYoYPZNdmXEG', null, 'Testing') ON CONFLICT DO NOTHING;
-INSERT INTO public.users (created_at, updated_at, about, email, password, signature, username) VALUES ('2021-11-20 21:22:36.115454', '2021-11-20 21:22:36.116453', null, 'foo@test.com', '$2a$10$xnUvv01NPMsvYQEYINiACOZTADPCoD9N6jjd7LSS4tYoYPZNdmXEG', null, 'Foo') ON CONFLICT DO NOTHING;
-INSERT INTO public.users (created_at, updated_at, about, email, password, signature, username) VALUES ('2021-11-20 21:22:36.115454', '2021-11-20 21:22:36.116453', null, 'bar@test.com', '$2a$10$xnUvv01NPMsvYQEYINiACOZTADPCoD9N6jjd7LSS4tYoYPZNdmXEG', null, 'Bar') ON CONFLICT DO NOTHING;
+INSERT INTO public.users (created_at, updated_at, about, email, password, signature, username) VALUES ('2021-11-20 21:22:36.115454', '2021-11-20 21:22:36.116453', '', 'test@test.com', '$2a$10$xnUvv01NPMsvYQEYINiACOZTADPCoD9N6jjd7LSS4tYoYPZNdmXEG', '', 'Testing') ON CONFLICT DO NOTHING;
+INSERT INTO public.users (created_at, updated_at, about, email, password, signature, username) VALUES ('2021-11-20 21:22:36.115454', '2021-11-20 21:22:36.116453', '', 'foo@test.com', '$2a$10$xnUvv01NPMsvYQEYINiACOZTADPCoD9N6jjd7LSS4tYoYPZNdmXEG', '', 'Foo') ON CONFLICT DO NOTHING;
+INSERT INTO public.users (created_at, updated_at, about, email, password, signature, username) VALUES ('2021-11-20 21:22:36.115454', '2021-11-20 21:22:36.116453', '', 'bar@test.com', '$2a$10$xnUvv01NPMsvYQEYINiACOZTADPCoD9N6jjd7LSS4tYoYPZNdmXEG', '', 'Bar') ON CONFLICT DO NOTHING;
 
 INSERT INTO public.users_roles (user_id, roles_id)
 SELECT

--- a/backend/src/test/java/ee/tlu/forum/controller/PostControllerTest.java
+++ b/backend/src/test/java/ee/tlu/forum/controller/PostControllerTest.java
@@ -53,6 +53,7 @@ class PostControllerTest {
                 "aaa",
                 new ArrayList<>(),
                 "",
+                0L,
                 "",
                 new ArrayList<>(),
                 new ArrayList<>());
@@ -82,6 +83,7 @@ class PostControllerTest {
                 "aaa",
                 new ArrayList<>(),
                 "",
+                0L,
                 "",
                 new ArrayList<>(),
                 new ArrayList<>());
@@ -110,6 +112,7 @@ class PostControllerTest {
                 "aaa",
                 new ArrayList<>(),
                 "",
+                0L,
                 "",
                 new ArrayList<>(),
                 new ArrayList<>());
@@ -148,6 +151,7 @@ class PostControllerTest {
                 "aaa",
                 new ArrayList<>(),
                 "",
+                0L,
                 "",
                 new ArrayList<>(),
                 new ArrayList<>());
@@ -184,6 +188,7 @@ class PostControllerTest {
                 "aaa",
                 new ArrayList<>(),
                 "",
+                0L,
                 "",
                 new ArrayList<>(),
                 new ArrayList<>());
@@ -218,6 +223,7 @@ class PostControllerTest {
                 "aaa",
                 new ArrayList<>(),
                 "",
+                0L,
                 "",
                 new ArrayList<>(),
                 new ArrayList<>());

--- a/backend/src/test/java/ee/tlu/forum/controller/ThreadControllerTest.java
+++ b/backend/src/test/java/ee/tlu/forum/controller/ThreadControllerTest.java
@@ -52,6 +52,7 @@ class ThreadControllerTest {
                 "aaa",
                 new ArrayList<>(),
                 "",
+                0L,
                 "",
                 new ArrayList<>(),
                 new ArrayList<>());
@@ -81,6 +82,7 @@ class ThreadControllerTest {
                 "aaa",
                 new ArrayList<>(),
                 "",
+                0L,
                 "",
                 new ArrayList<>(),
                 new ArrayList<>());
@@ -108,6 +110,7 @@ class ThreadControllerTest {
                 "aaa",
                 new ArrayList<>(),
                 "",
+                0L,
                 "",
                 new ArrayList<>(),
                 new ArrayList<>());
@@ -146,6 +149,7 @@ class ThreadControllerTest {
                 "aaa",
                 new ArrayList<>(),
                 "",
+                0L,
                 "",
                 new ArrayList<>(),
                 new ArrayList<>());
@@ -183,6 +187,7 @@ class ThreadControllerTest {
                 "aaa",
                 new ArrayList<>(),
                 "",
+                0L,
                 "",
                 new ArrayList<>(),
                 new ArrayList<>());
@@ -214,6 +219,7 @@ class ThreadControllerTest {
                 "aaa",
                 new ArrayList<>(),
                 "",
+                0L,
                 "",
                 new ArrayList<>(),
                 new ArrayList<>());
@@ -244,6 +250,7 @@ class ThreadControllerTest {
                 "aaa",
                 new ArrayList<>(),
                 "",
+                0L,
                 "",
                 new ArrayList<>(),
                 new ArrayList<>());

--- a/backend/src/test/java/ee/tlu/forum/controller/UserControllerTest.java
+++ b/backend/src/test/java/ee/tlu/forum/controller/UserControllerTest.java
@@ -52,6 +52,7 @@ class UserControllerTest {
                 "aaa",
                 roles,
                 "",
+                0L,
                 "",
                 new ArrayList<>(),
                 new ArrayList<>());
@@ -78,6 +79,7 @@ class UserControllerTest {
                 "123123123",
                 roles,
                 "",
+                0L,
                 "",
                 new ArrayList<>(),
                 new ArrayList<>());
@@ -114,6 +116,7 @@ class UserControllerTest {
                 "aaa",
                 new ArrayList<>(),
                 "",
+                0L,
                 "",
                 new ArrayList<>(),
                 new ArrayList<>());
@@ -144,6 +147,7 @@ class UserControllerTest {
                 "aaa",
                 new ArrayList<>(),
                 "",
+                0L,
                 "",
                 new ArrayList<>(),
                 new ArrayList<>());


### PR DESCRIPTION
And various fixes

By accessing GET `/api/user/{username}/profile`, it returns the whole user information and increments visitor count
eg `localhost:8080/api/user/Testing/profile` - try it out.

GET `/api/user/{username}/threadcount` returns user thread count

GET `/api/user/{username}/postcount` returns user post count

GET `/api/user/{username}/visitors` returns user profile visit count

Full list of endpoints here as always `http://localhost:8080/swagger-ui/`

I'm not restricting much of the endpoints yet for just users/admin (so you wouldn't have to constantly log in to test), let's keep it for the end of the next sprint! :D
